### PR TITLE
Validate update with blank field

### DIFF
--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -67,6 +67,12 @@ class UserUpdate(UserBase):
         if not any(values.values()):
             raise ValueError("At least one field must be provided for update")
         return values
+    
+    @field_validator("bio", "first_name", "last_name")
+    def check_no_blank_strings(cls, values):
+        if values == "":
+            raise ValueError("An empty string was entered for this field")
+        return values
 
 class UserResponse(UserBase):
     id: uuid.UUID = Field(..., example=uuid.uuid4())

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,7 @@ There exists a scenario in which a user may attempt to update their profile wher
 Initially there was some basic validation for user nicknames, but no max length. Lacking standardization may cause unexpected problems with the database or UI down the line, so it would be best to fix this. A max length validator was added to the schema and a test was added to ensure overlong nicknames are not accepted. Here is the link to the [closed issue](https://github.com/atwoodmachine/is601_homework10/issues/18)
 
 ### Issue 6
+There was no existing validation for the fields of bio, first name, or last name to prevent them from being entered as empty strings, which may unintentionally overwrite data. Validation to ensure these values are not blank when being updated was added to the user schema, as well as tests to ensure attempted updates with blank fields are not permitted. Here is the link to the [closed issue](https://github.com/atwoodmachine/is601_homework10/issues/20)
 
 ### Issue 7
 When first running the project, several tests fail because there is a mismatch in testing fixtures and the given schema. Particularly, the attributes "full_name" and "username" are used instead of the accurate "first_name", "last_name", and "nickname" fields. These were renamed and the tests pass with expected behavior. Here is the link to the [closed issue](https://github.com/atwoodmachine/is601_homework10/issues/3)

--- a/tests/test_services/test_user_service.py
+++ b/tests/test_services/test_user_service.py
@@ -91,6 +91,15 @@ async def test_update_valid_and_invalid_fields(db_session, user):
     updated_user = await UserService.update(db_session, user.id, {"bio": "Richard who loves python", "github_profile_url": "oopsie!"})
     assert updated_user is None
 
+#Test empty strings don't wipe data by mistake
+async def test_update_blank_bio(db_session, user):
+    updated_user = await UserService.update(db_session, user.id, {"first_name": "Josh", "bio": ""})
+    assert updated_user is None
+
+async def test_update_blank_names(db_session, user):
+    updated_user = await UserService.update(db_session, user.id, {"first_name": "", "last_name": "", "bio": "Some guy"})
+    assert updated_user is None
+
 # Test deleting a user who exists
 async def test_delete_user_exists(db_session, user):
     deletion_success = await UserService.delete(db_session, user.id)


### PR DESCRIPTION
closes #20 by checking to make sure fields are not blank and preventing updates if blank fields are provided